### PR TITLE
Make high-DPI awareness setting work on Win7

### DIFF
--- a/dgs_chill.vcxproj
+++ b/dgs_chill.vcxproj
@@ -138,7 +138,7 @@
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <EnableUAC>false</EnableUAC>
       <ModuleDefinitionFile>dgs_chill.def</ModuleDefinitionFile>
-      <AdditionalDependencies>%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>User32.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
@@ -159,7 +159,7 @@
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <EnableUAC>false</EnableUAC>
       <ModuleDefinitionFile>dgs_chill.def</ModuleDefinitionFile>
-      <AdditionalDependencies>%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>User32.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup>

--- a/dllmain.cpp
+++ b/dllmain.cpp
@@ -2,7 +2,7 @@
 
 #include <Windows.h>
 //#include <dinput.h>
-#include <shellscalingapi.h>
+#include <WinUser.h>
 
 #include <cstdio>
 
@@ -343,18 +343,6 @@ static void FixJuryPitCrash() {
 	VirtualProtect(page_addr, 0x1000, page_old_attr, &tmpdword);
 }
 
-static void SetHighDpiAware() {
-	HMODULE dll = ::LoadLibraryW(L"api-ms-win-shcore-scaling-l1-1-1.dll");
-	if (!dll)
-		return;
-	void* addr = ::GetProcAddress(dll, "SetProcessDpiAwareness");
-	if (addr) {
-		PSetProcessDpiAwareness func = static_cast<PSetProcessDpiAwareness>(addr);
-		func(1);
-	}
-	::FreeLibrary(dll);
-}
-
 static void* SetupHacks() {
 	INIReader ini("dgs.ini");
 
@@ -364,7 +352,7 @@ static void* SetupHacks() {
 		return nullptr;
 
 	if (ini.GetBoolean("Main", "ReportAsHighDpiAware", true)) {
-		SetHighDpiAware();
+		SetProcessDPIAware();
 	}
 
 	// run at 60 fps or whatever


### PR DESCRIPTION
Since the game does run on Win7 (while the official minimum requirements talk about Win8.1/10), these changes should allow the system-DPI awareness setting to work on Win7 systems, too, using a Windows API call available since Vista, which also allow to set system-DPI awareness.
https://docs.microsoft.com/en-us/windows/win32/api/winuser/nf-winuser-setprocessdpiaware

I'm not sure if TGAAC runs on Vista, but theoretically system the high-DPI awareness setting should also work on Vista.